### PR TITLE
`:Q` is unnecessary

### DIFF
--- a/_sources/tutorials/exploring-weather.txt
+++ b/_sources/tutorials/exploring-weather.txt
@@ -137,7 +137,7 @@ and refer to this new data by name as we would with any other column:
 
     Chart(df).mark_line().encode(
         X('date:T', timeUnit='month'),
-        y='mean(temp_range):Q'
+        y='mean(temp_range)'
     ).transform_data(
         calculate=[temp_range],
     )


### PR DESCRIPTION
There was nothing when we test `'mean(temp_range):Q'` in Jupyter Notebook. It's ok when we delete `:Q`.

Change the code

```python
Chart(df).mark_line().encode(
        X('date:T', timeUnit='month'),
        y='mean(temp_range):Q'
    ).transform_data(
        calculate=[temp_range],
    )
```

to

```python
Chart(df).mark_line().encode(
        X('date:T', timeUnit='month'),
        y='mean(temp_range)'
    ).transform_data(
        calculate=[temp_range],
    )
```