### PR TITLE
Added a troubleshooting tip related to layered charts

### DIFF
--- a/_sources/user_guide/compound_charts.rst.txt
+++ b/_sources/user_guide/compound_charts.rst.txt
@@ -64,6 +64,12 @@ number of charts:
 The output of both of these patterns is a :class:`LayerChart` object, which
 has properties and methods similar to the :class:`Chart` object.
 
+.. note::
+
+   The bottom-layer is the chart on the left side of the ``+`` operator, or
+   the one that was passed as the first argument of ``alt.layer``. If you do not
+   see the expected output, check the order of the layers.
+
 
 .. _hconcat-chart:
 

--- a/_sources/user_guide/compound_charts.rst.txt
+++ b/_sources/user_guide/compound_charts.rst.txt
@@ -62,7 +62,7 @@ number of charts:
     ).interactive()
 
 The output of both of these patterns is a :class:`LayerChart` object, which
-can has properties and methods similar to the :class:`Chart` object.
+has properties and methods similar to the :class:`Chart` object.
 
 
 .. _hconcat-chart:


### PR DESCRIPTION
Based on this thread of discussion group: https://groups.google.com/forum/#!topic/altair-viz/Vj6OY1HwMiY

> `heat_map + labels` vs `labels + heat_map`
> The numbers were on the bottom layer, thus obscured by the rectangles, giving the impression that it did not work. However, the software did _exactly_ what I asked :-)
> In retrospect, it is an obvious error. What would have helped me, is an adnotation at the end of the `layer` section, hinting the reader about double-checking the order of the layers if the result is not right. 

