### PR TITLE
Typo: Changed Alair to Altair

### DIFF
--- a/user_guide/encoding.html
+++ b/user_guide/encoding.html
@@ -218,7 +218,7 @@
 <span id="user-guide-encoding"></span><h1>Encodings<a class="headerlink" href="#encodings" title="Permalink to this headline">¶</a></h1>
 <p>The key to creating meaningful visualizations is to map <em>properties of the data</em>
 to <em>visual properties</em> in order to effectively communicate information.
-In Alair, this mapping of visual properties to data columns is referred to
+In Altair, this mapping of visual properties to data columns is referred to
 as an <strong>encoding</strong>, and is most often expressed through the <code class="xref py py-meth docutils literal"><span class="pre">Chart.encode()</span></code>
 method.</p>
 <p>For example, here we will visualize the cars dataset using four of the available


### PR DESCRIPTION
In HTML file encoding.html, the word Altair is misspelled as Alair. 